### PR TITLE
Changed body type in private sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "luxon": "^2.1.1",
                 "multer": "^1.4.5-lts.1",
                 "nunjucks": "^3.2.3",
-                "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.81",
+                "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.82",
                 "reflect-metadata": "^0.1.13",
                 "uuid": "^8.3.2",
                 "yargs": "^15.4.1"
@@ -6465,7 +6465,7 @@
         },
         "node_modules/private-api-sdk-node": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#c9a0c5fea8fd37aaec501d04aeae903254b44218",
+            "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#451b74bdc32bd6ac9ed2693e42bce5c097a5d289",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -13254,8 +13254,8 @@
             }
         },
         "private-api-sdk-node": {
-            "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#c9a0c5fea8fd37aaec501d04aeae903254b44218",
-            "from": "private-api-sdk-node@github:companieshouse/private-api-sdk-node#0.1.81",
+            "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#451b74bdc32bd6ac9ed2693e42bce5c097a5d289",
+            "from": "private-api-sdk-node@github:companieshouse/private-api-sdk-node#0.1.82",
             "requires": {
                 "@companieshouse/api-sdk-node": "^2.0.70",
                 "@types/node": "~18.15.11",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "luxon": "^2.1.1",
         "multer": "^1.4.5-lts.1",
         "nunjucks": "^3.2.3",
-        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.81",
+        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.82",
         "reflect-metadata": "^0.1.13",
         "uuid": "^8.3.2",
         "yargs": "^15.4.1"


### PR DESCRIPTION
- Upgrade `private-api-sdk-node` to new version that has the body type of string for a base64 encoded file.