### PR TITLE
Remove api enumerations from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ ifndef version
 endif
 	$(info Packaging version: $(version))
 	$(eval tmpdir := $(shell mktemp -d build-XXXXXXXXXX))
-	mkdir $(tmpdir)/api-enumerations
-	cp ./api-enumerations/*.yml $(tmpdir)/api-enumerations
+	# mkdir $(tmpdir)/api-enumerations
+	# cp ./api-enumerations/*.yml $(tmpdir)/api-enumerations
 	cp -r ./dist/* $(tmpdir)
 	cp -r ./package.json $(tmpdir)
 	cp -r ./package-lock.json $(tmpdir)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@companieshouse/api-sdk-node": "^2.0.70",
                 "@companieshouse/structured-logging-node": "^1.0.4",
-                "@companieshouse/web-security-node": "^2.0.0",
                 "cookie-parser": "^1.4.6",
                 "express": "^4.17.1",
                 "govuk-frontend": "^3.14.0",
@@ -715,19 +714,6 @@
                 "url-search-params-polyfill": "~8.1.1"
             }
         },
-        "node_modules/@companieshouse/node-session-handler": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-4.1.9.tgz",
-            "integrity": "sha512-/rTDzTQuOHiAJM8VQmSbBMx20QMIhWElgkzokFQF+6xVKsYz7FHVNGRmhNfx8xhhBHE6oTb+jYXM57rd15HNfQ==",
-            "dependencies": {
-                "@companieshouse/structured-logging-node": "~1.0.0",
-                "crypto": "^1.0.1",
-                "express-async-handler": "^1.1.4",
-                "ioredis": "^4.17.3",
-                "msgpack5": "^4.5.1",
-                "on-headers": "^1.0.2"
-            }
-        },
         "node_modules/@companieshouse/structured-logging-node": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@companieshouse/structured-logging-node/-/structured-logging-node-1.0.8.tgz",
@@ -736,15 +722,6 @@
                 "moment": "^2.29.4",
                 "on-finished": "~2.3.0",
                 "winston": "~3.3.3"
-            }
-        },
-        "node_modules/@companieshouse/web-security-node": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.3.tgz",
-            "integrity": "sha512-xOxm4LZRKJxie6z7zGoTYRd4lwawkt8R5fnVfZPkHfP8N0a/KXx91CVnFMIvKhEBovyzmdIxjrRnzwc2fDRxRA==",
-            "dependencies": {
-                "@companieshouse/node-session-handler": "~4.1.4",
-                "@companieshouse/structured-logging-node": "~1.0.3"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -2275,47 +2252,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/bl": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-            "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-            "dependencies": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/bl/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/bl/node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "node_modules/bl/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/bl/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
         "node_modules/body-parser": {
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -2667,14 +2603,6 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
-        "node_modules/cluster-key-slot": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2894,12 +2822,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/crypto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-            "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-            "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
-        },
         "node_modules/cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2942,6 +2864,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2957,7 +2880,8 @@
         "node_modules/debug/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
@@ -3158,14 +3082,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/denque": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/depd": {
@@ -3795,11 +3711,6 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
-        },
-        "node_modules/express-async-handler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
-            "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
         },
         "node_modules/express/node_modules/cookie": {
             "version": "0.5.0",
@@ -4500,31 +4411,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/ioredis": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-            "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-            "dependencies": {
-                "cluster-key-slot": "^1.1.0",
-                "debug": "^4.3.1",
-                "denque": "^1.1.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isarguments": "^3.1.0",
-                "p-map": "^2.1.0",
-                "redis-commands": "1.7.0",
-                "redis-errors": "^1.2.0",
-                "redis-parser": "^3.0.0",
-                "standard-as-callback": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ioredis"
-            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -5626,26 +5512,11 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "node_modules/lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-        },
-        "node_modules/lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
-        },
         "node_modules/lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "dev": true
-        },
-        "node_modules/lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -5886,49 +5757,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
-        "node_modules/msgpack5": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-4.5.1.tgz",
-            "integrity": "sha512-zC1vkcliryc4JGlL6OfpHumSYUHWFGimSI+OgfRCjTFLmKA2/foR9rMTOhWiqfOrfxJOctrpWPvrppf8XynJxw==",
-            "dependencies": {
-                "bl": "^2.0.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.3.6",
-                "safe-buffer": "^5.1.2"
-            }
-        },
-        "node_modules/msgpack5/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/msgpack5/node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "node_modules/msgpack5/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/msgpack5/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
         "node_modules/multer": {
             "version": "1.4.5-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
@@ -6165,14 +5993,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6245,14 +6065,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/p-try": {
@@ -6661,30 +6473,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/redis-commands": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-        },
-        "node_modules/redis-errors": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/redis-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-            "dependencies": {
-                "redis-errors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/reflect-metadata": {
@@ -7235,11 +7023,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/standard-as-callback": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "node_modules/statuses": {
             "version": "2.0.1",
@@ -8824,19 +8607,6 @@
                 "url-search-params-polyfill": "~8.1.1"
             }
         },
-        "@companieshouse/node-session-handler": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-4.1.9.tgz",
-            "integrity": "sha512-/rTDzTQuOHiAJM8VQmSbBMx20QMIhWElgkzokFQF+6xVKsYz7FHVNGRmhNfx8xhhBHE6oTb+jYXM57rd15HNfQ==",
-            "requires": {
-                "@companieshouse/structured-logging-node": "~1.0.0",
-                "crypto": "^1.0.1",
-                "express-async-handler": "^1.1.4",
-                "ioredis": "^4.17.3",
-                "msgpack5": "^4.5.1",
-                "on-headers": "^1.0.2"
-            }
-        },
         "@companieshouse/structured-logging-node": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@companieshouse/structured-logging-node/-/structured-logging-node-1.0.8.tgz",
@@ -8845,15 +8615,6 @@
                 "moment": "^2.29.4",
                 "on-finished": "~2.3.0",
                 "winston": "~3.3.3"
-            }
-        },
-        "@companieshouse/web-security-node": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.3.tgz",
-            "integrity": "sha512-xOxm4LZRKJxie6z7zGoTYRd4lwawkt8R5fnVfZPkHfP8N0a/KXx91CVnFMIvKhEBovyzmdIxjrRnzwc2fDRxRA==",
-            "requires": {
-                "@companieshouse/node-session-handler": "~4.1.4",
-                "@companieshouse/structured-logging-node": "~1.0.3"
             }
         },
         "@cspotcode/source-map-support": {
@@ -10024,53 +9785,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "devOptional": true
         },
-        "bl": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-            "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-            "requires": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
-                    }
-                }
-            }
-        },
         "body-parser": {
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -10314,11 +10028,6 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
-        "cluster-key-slot": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
-        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10509,11 +10218,6 @@
                 "which": "^2.0.1"
             }
         },
-        "crypto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-            "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-        },
         "cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -10552,6 +10256,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             },
@@ -10559,7 +10264,8 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
@@ -10727,11 +10433,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true
-        },
-        "denque": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
         },
         "depd": {
             "version": "2.0.0",
@@ -11244,11 +10945,6 @@
                 }
             }
         },
-        "express-async-handler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
-            "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -11739,24 +11435,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "ioredis": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-            "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-            "requires": {
-                "cluster-key-slot": "^1.1.0",
-                "debug": "^4.3.1",
-                "denque": "^1.1.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isarguments": "^3.1.0",
-                "p-map": "^2.1.0",
-                "redis-commands": "1.7.0",
-                "redis-errors": "^1.2.0",
-                "redis-parser": "^3.0.0",
-                "standard-as-callback": "^2.1.0"
-            }
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -12615,26 +12293,11 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-        },
-        "lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
-        },
         "lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "dev": true
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -12817,55 +12480,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
-        "msgpack5": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-4.5.1.tgz",
-            "integrity": "sha512-zC1vkcliryc4JGlL6OfpHumSYUHWFGimSI+OgfRCjTFLmKA2/foR9rMTOhWiqfOrfxJOctrpWPvrppf8XynJxw==",
-            "requires": {
-                "bl": "^2.0.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.3.6",
-                "safe-buffer": "^5.1.2"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                        }
-                    }
-                }
-            }
-        },
         "multer": {
             "version": "1.4.5-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
@@ -13037,11 +12651,6 @@
                 "ee-first": "1.1.1"
             }
         },
-        "on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13097,11 +12706,6 @@
             "requires": {
                 "p-limit": "^2.2.0"
             }
-        },
-        "p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         },
         "p-try": {
             "version": "2.2.0",
@@ -13398,24 +13002,6 @@
             "devOptional": true,
             "requires": {
                 "picomatch": "^2.2.1"
-            }
-        },
-        "redis-commands": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-        },
-        "redis-errors": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
-        },
-        "redis-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-            "requires": {
-                "redis-errors": "^1.0.0"
             }
         },
         "reflect-metadata": {
@@ -13833,11 +13419,6 @@
                     "dev": true
                 }
             }
-        },
-        "standard-as-callback": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "statuses": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dependencies": {
         "@companieshouse/api-sdk-node": "^2.0.70",
         "@companieshouse/structured-logging-node": "^1.0.4",
-        "@companieshouse/web-security-node": "^2.0.0",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "govuk-frontend": "^3.14.0",

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,32 +1,11 @@
-import { Session } from "@companieshouse/node-session-handler";
-import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
-import { AccessTokenKeys } from "@companieshouse/node-session-handler/lib/session/keys/AccessTokenKeys";
 import { API_URL, CHS_API_KEY, CHS_INTERNAL_API_KEY, INTERNAL_API_URL } from "../config";
-import { createAndLogError } from "../utils/logger";
 import { createApiClient } from "@companieshouse/api-sdk-node/dist";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
 import { createPrivateApiClient } from "private-api-sdk-node";
 import PrivateApiClient from 'private-api-sdk-node/dist/client';
 
-export const createPublicOAuthApiClient = (session: Session): ApiClient => {
-    const oAuth = session.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken];
-    if (oAuth) {
-        return createApiClient(undefined, oAuth, API_URL);
-    }
-    throw createAndLogError("Error getting session keys for creating public api client");
-};
-
 export const createPublicApiKeyClient = (): ApiClient => {
     return createApiClient(CHS_API_KEY, undefined, API_URL);
-};
-
-export const createPrivateOAuthApiClient = (session: Session): PrivateApiClient => {
-    const oAuth = session.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken];
-    if (oAuth) {
-        return createPrivateApiClient(undefined, oAuth, INTERNAL_API_URL);
-    }
-    throw createAndLogError("Error getting session keys for creating private api client");
 };
 
 export const createPrivateApiKeyClient = (): PrivateApiClient => {


### PR DESCRIPTION
The makefile had references in the makefile package step that caused the pipeline to fail. This PR removes them.

It also removes `web-security-node` and the oauth api client factory functions. The reason for this is that this service doesn't use sessions or require a login. This means it is impossible to use oauth to create an API client.