### PR TITLE
Accept HTML files

### DIFF
--- a/src/controllers/submit.controller.ts
+++ b/src/controllers/submit.controller.ts
@@ -55,7 +55,7 @@ function validateForm(file?: Express.Multer.File) {
 }
 
 const allowedFileExtensions = [
-    "zip", "xhtml"
+    "zip", "xhtml", "html"
 ];
 
 function extention(filename: string) {

--- a/test/controller/render.controller.unit.ts
+++ b/test/controller/render.controller.unit.ts
@@ -13,7 +13,7 @@ describe('Result controller tests', () => {
 
     it('should return pdf buffer', async () => {
         const fileId = 'file123';
-        const body = Buffer.from("", "binary").buffer;
+        const body = "";
         const mockResult: File = {
             fileName: "",
             body: body,

--- a/test/service/image.render.service.unit.ts
+++ b/test/service/image.render.service.unit.ts
@@ -15,7 +15,7 @@ const mockLocalAPIClient = {
 
 function createAccountValidatorResponse(
     httpStatusCode: number,
-    body: ArrayBuffer,
+    body: "",
     fileId: string,
     mimeType: string,
     size: number,
@@ -92,7 +92,7 @@ describe("ImageRender", () => {
     it("should return an AccountValidationResult if the request is successful", async () => {
         // Given
         const fileId = "fileId";
-        const body = Buffer.from("").buffer;
+        const body = "";
         const resource = createAccountValidatorResponse(
             200,
             body,


### PR DESCRIPTION
This PR allows the `account-validator-web` to accept files with the `.html` extension.
It also fixes a warning about types in the unit tests