### PR TITLE
Don't copy routes.yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 	cp -r ./package-lock.json $(tmpdir)
 	cp -r ./.git $(tmpdir)
 	cp ./start.sh $(tmpdir)
-	cp ./routes.yaml $(tmpdir)
+	# cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && npm ci --production
 	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 	cp -r ./package-lock.json $(tmpdir)
 	cp -r ./.git $(tmpdir)
 	cp ./start.sh $(tmpdir)
-	# cp ./routes.yaml $(tmpdir)
+	cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && npm ci --production
 	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .

--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,5 @@
+app_name: account-validator-web
+group: standalone
+
+weight: 100
+routes: {}


### PR DESCRIPTION
Fixed makefile so it doesn't fail trying to copy a routes file that isn't there