### PR TITLE
Add standalone routes files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 	cp -r ./package-lock.json $(tmpdir)
 	cp -r ./.git $(tmpdir)
 	cp ./start.sh $(tmpdir)
-	cp ./routes.yaml $(tmpdir)
+	# cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && npm ci --production
 	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 	cp -r ./package-lock.json $(tmpdir)
 	cp -r ./.git $(tmpdir)
 	cp ./start.sh $(tmpdir)
-	# cp ./routes.yaml $(tmpdir)
+	cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && npm ci --production
 	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .

--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,5 @@
+app_name: account-validator-web
+group: standalone
+
+weight: 100
+routes: {}


### PR DESCRIPTION
`routes.yaml` file was removed as it was thought it wasn't needed. 
However, it is needed for the pipeline. This PR re-adds the `routes.yaml` file but with no routes in.