### PR TITLE
Actually removed the file this time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ endif
 	cp -r ./package-lock.json $(tmpdir)
 	cp -r ./.git $(tmpdir)
 	cp ./start.sh $(tmpdir)
-	cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && npm ci --production
 	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .

--- a/routes.yaml
+++ b/routes.yaml
@@ -1,5 +1,0 @@
-app_name: account-validator-web
-group: standalone
-
-weight: 100
-routes: {}


### PR DESCRIPTION
Seems like the routes file needs atleast one route. 
I thoguht that the `ci-environment-shcroniser` needed a routes file, but I found [the code that checks if a routes file is present](https://github.com/companieshouse/ci-environment-state-synchroniser/blob/39a9b1e7af4727e034a6d6865c83b2eb48869701/src/main/java/uk/gov/companieshouse/environment/synchroniser/service/impl/YamlConfigurationService.java#L57), so it should be fine without it.