### PR TITLE
Bump private api version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "luxon": "^2.1.1",
                 "multer": "^1.4.5-lts.1",
                 "nunjucks": "^3.2.3",
-                "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.86",
+                "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.87",
                 "reflect-metadata": "^0.1.13",
                 "uuid": "^8.3.2",
                 "yargs": "^15.4.1"
@@ -6318,7 +6318,7 @@
         },
         "node_modules/private-api-sdk-node": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#f840755c638b5a52bf167aa3a1433a247013d63e",
+            "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#8c991783eea4d7f5d02578ee0cdaa23b195b5e7e",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -13017,8 +13017,8 @@
             }
         },
         "private-api-sdk-node": {
-            "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#f840755c638b5a52bf167aa3a1433a247013d63e",
-            "from": "private-api-sdk-node@github:companieshouse/private-api-sdk-node#0.1.86",
+            "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#8c991783eea4d7f5d02578ee0cdaa23b195b5e7e",
+            "from": "private-api-sdk-node@github:companieshouse/private-api-sdk-node#0.1.87",
             "requires": {
                 "@companieshouse/api-sdk-node": "^2.0.71",
                 "@types/node": "~18.15.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "luxon": "^2.1.1",
         "multer": "^1.4.5-lts.1",
         "nunjucks": "^3.2.3",
-        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.86",
+        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.87",
         "reflect-metadata": "^0.1.13",
         "uuid": "^8.3.2",
         "yargs": "^15.4.1"


### PR DESCRIPTION
update private api version to include a new error status