### PR TITLE
Increase max request size for file submission

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,7 +26,7 @@ export const COOKIE_SECRET = getEnvironmentVariable("COOKIE_SECRET");
 export const INTERNAL_API_URL = getEnvironmentVariable("INTERNAL_API_URL");
 export const CHS_INTERNAL_API_KEY = getEnvironmentVariable("CHS_INTERNAL_API_KEY");
 export const PORT = parseInt(getEnvironmentVariable("PORT", 3000));
-export const RESULT_RELOAD_DURATION_SECONDS = parseFloat(getEnvironmentVariable("RESULT_RELOAD_DURATION_SECONDS", 1));
+export const RESULT_RELOAD_DURATION_SECONDS = parseFloat(getEnvironmentVariable("RESULT_RELOAD_DURATION_SECONDS", 5));
 export const SURVEY_LINK = getEnvironmentVariable("SURVEY_LINK", "");
 
 /**

--- a/src/services/account.validation.service.ts
+++ b/src/services/account.validation.service.ts
@@ -213,7 +213,9 @@ export class AccountValidator implements AccountValidationService {
 
 
         // TODO: Change body type to string
-        const fileDetails: File =  { fileName: file.originalname, body: file.buffer.toString("base64"), mimeType: file.mimetype, size: file.size, extension: '.xtml' };
+        const body = file.buffer.toString("base64");
+        logger.debug(`Body size: ${body.length} Sample ${body.slice(0, 10)}`);
+        const fileDetails: File =  { fileName: file.originalname, body: body, mimeType: file.mimetype, size: file.size, extension: '.xtml' };
 
         const fileTransferService = this.privateApiClient.fileTransferService;
         logger.debug(`Uploading file ${fileDetails.fileName} to S3.`);

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,20 +1,46 @@
-import { API_URL, CHS_API_KEY, CHS_INTERNAL_API_KEY, INTERNAL_API_URL } from "../config";
-import { createApiClient } from "@companieshouse/api-sdk-node/dist";
+import {
+    API_URL,
+    CHS_API_KEY,
+    CHS_INTERNAL_API_KEY,
+    INTERNAL_API_URL,
+    MAX_FILE_SIZE,
+} from "../config";
+import {
+    RequestClient,
+    createApiClient,
+} from "@companieshouse/api-sdk-node/dist";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
 import { createPrivateApiClient } from "private-api-sdk-node";
-import PrivateApiClient from 'private-api-sdk-node/dist/client';
+import PrivateApiClient from "private-api-sdk-node/dist/client";
 import { logger } from "../utils/logger";
+import {
+    AdditionalOptions,
+    HttpResponse,
+} from "@companieshouse/api-sdk-node/dist/http/http-client";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
 export const createPublicApiKeyClient = (): ApiClient => {
     return createApiClient(CHS_API_KEY, undefined, API_URL);
 };
 
 export const createPrivateApiKeyClient = (): PrivateApiClient => {
-    logger.info(`Creating private API client with key ${maskString(CHS_INTERNAL_API_KEY)}`);
+    logger.info(
+        `Creating private API client with key ${maskString(
+            CHS_INTERNAL_API_KEY
+        )}`
+    );
 
-    return createPrivateApiClient(CHS_INTERNAL_API_KEY, undefined, INTERNAL_API_URL);
+    const sdkClient =  createPrivateApiClient(
+        CHS_INTERNAL_API_KEY,
+        undefined,
+        INTERNAL_API_URL
+    );
+
+    const apiClient = new LargeBodyRequestClient(sdkClient.apiClient as RequestClient, base64Size(MAX_FILE_SIZE));
+
+
+    return new PrivateApiClient(apiClient, sdkClient.accountClient);
 };
-
 
 /**
  * Masks a string by replacing characters after a specified position with a mask character.
@@ -29,8 +55,71 @@ export const createPrivateApiKeyClient = (): PrivateApiClient => {
  * const masked = maskString(input);
  * console.log(masked); // Output: "Hello,******"
  */
-function maskString(s: string, n = 5, mask = '*'): string {
-    return [...s]
-        .map((char, index) => (index < n ? char : mask))
-        .join("");
+function maskString(s: string, n = 5, mask = "*"): string {
+    return [...s].map((char, index) => (index < n ? char : mask)).join("");
+}
+
+class LargeBodyRequestClient extends RequestClient {
+    constructor(requestClient: RequestClient, private maxBodySize: number) {
+        super(requestClient["options"]);
+        // Override private method
+        this["request"] = this.largeRequest;
+    }
+
+    private async largeRequest(
+        additionalOptions: AdditionalOptions
+    ): Promise<HttpResponse> {
+        try {
+            const options: AxiosRequestConfig = {
+                method: additionalOptions.method,
+                headers: {
+                    ...this.headers,
+                    ...additionalOptions.headers,
+                },
+                url: `${this.options.baseUrl}${additionalOptions.url}`,
+                data: additionalOptions.body,
+                responseType: "json",
+                maxBodyLength: this.maxBodySize,
+                maxContentLength: this.maxBodySize,
+
+                validateStatus: () => true,
+            };
+
+            // any errors (including status code errors) are thrown as exceptions and
+            // will be caught in the catch block.
+            const resp = (await axios(options)) as AxiosResponse;
+            return {
+                status: resp.status,
+                body: resp.data,
+                headers: resp.headers,
+            };
+        } catch (e) {
+            // e can be an instance of AxiosError or a generic error
+            // however, we cannot specify a type for e coz type annotations for catch block errors must be 'any' or 'unknown' if specified
+            const error = e?.response?.data || {
+                message: "failed to execute http request",
+            };
+            return {
+                status: e?.status || 500,
+                error,
+            };
+        }
+    }
+}
+
+/**
+ * Calculates the size of data after Base64 encoding.
+ *
+ * Base64 encoding inflates the size of the data by approximately 33%.
+ * Every 3 bytes of data gets converted into 4 bytes of Base64-encoded data.
+ *
+ * @param sizeInBytes - The original size of data in bytes.
+ * @returns The size of the data in bytes after Base64 encoding, including necessary padding.
+ */
+function base64Size(sizeInBytes: number) {
+    const base64Size = Math.ceil((sizeInBytes * 4) / 3);
+
+    const padding = base64Size % 4 === 0 ? 0 : 4 - (base64Size % 4);
+
+    return base64Size + padding;
 }


### PR DESCRIPTION
`api-sdk-node` has a max request size which is not configurable and prevented large files being submitted. This PR extends the api sdk http client and overrides the request method to allow large requests