### PR TITLE
Remove preview image text for zips

### DIFF
--- a/views/result/account.validation.success.html
+++ b/views/result/account.validation.success.html
@@ -18,9 +18,9 @@
     html: html
 }) }}
 
-<p class="govuk-body">Preview the image that will be published on the Companies House register.</p>
 
 {% if accountValidationResult.imageUrl %}
+    <p class="govuk-body">Preview the image that will be published on the Companies House register.</p>
     <div>
         {{ govukButton({
                 text: "Show image",


### PR DESCRIPTION
Removes the ''Preview the image that will be published on the Companies House register" text for ZIP submissions.

See [Acceptance Criteria 1](https://companieshouse.atlassian.net/browse/BI-12962).