### PR TITLE
Adding test-unit in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ lint:
 sonar:
 	npm run sonarqube
 
+.PHONY: test-unit
+test-unit:
+	npm run test
+
 .PHONY: test
 test:
 	npm run coverage


### PR DESCRIPTION
Adding new entry for test-unit. Test-unit is required by pipeline.