### PR TITLE
Added protocol to CDN URL configs

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -7,7 +7,7 @@ account_validator_max_file_size = "300MB"
 allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
 
 cache_server = "redis"
-cdn_host = "d3uvya5a8a1ncx.cloudfront.net"
+cdn_host = "https://d3uvya5a8a1ncx.cloudfront.net"
 
 chs_url = "https://cidev.aws.chdev.org"
 

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -6,7 +6,7 @@ api_url = "https://private-api.companieshouse.gov.uk"
 account_validator_max_file_size = "300MB"
 allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
 cache_server = "redis"
-cdn_host = "db2062spq951s.cloudfront.net"
+cdn_host = "https://db2062spq951s.cloudfront.net"
 
 chs_url = "https://staging.company-information.service.gov.uk"
 

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -6,7 +6,7 @@ api_url = "https://private-api-staging.company-information.service.gov.uk"
 account_validator_max_file_size = "300MB"
 allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
 cache_server = "redis"
-cdn_host = "d6nh3dxv55e16.cloudfront.net"
+cdn_host = "https://d6nh3dxv55e16.cloudfront.net"
 
 chs_url = "https://staging.company-information.service.gov.uk"
 


### PR DESCRIPTION
The CDN_HOST config variable didn't have a protocol (e.g. http or https). 
This caused the styles to not load.
This PR simply adds a protocol to these variables.

Resolves: [CC-766](https://companieshouse.atlassian.net/browse/CC-766)

[CC-766]: https://companieshouse.atlassian.net/browse/CC-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ