### PR TITLE
Fix-routing-path-to-include-sub-paths

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -6,7 +6,7 @@ locals {
   container_port            = "3000" # default node port required here until prod docker container is built allowing port change via env var
   docker_repo               = "account-validator-web"
   lb_listener_rule_priority = 16
-  lb_listener_paths         = ["/xbrl_validate"]
+  lb_listener_paths         = ["/xbrl_validate", "/xbrl_validate/*"]
   healthcheck_path          = "/xbrl_validate/healthcheck" #healthcheck path for account-validator-web
   healthcheck_matcher       = "200"                        # no explicit healthcheck in this service yet, change this when added!
 


### PR DESCRIPTION
LB path was only routing to `/xbrl_validate` and not sub paths.
This PR adds a wildcard to the LB paths so ub-paths are now correctly routed to the service.