### PR TITLE
Remove express sse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "axios": "^1.5.0",
                 "cookie-parser": "^1.4.6",
                 "express": "^4.18.2",
-                "express-sse": "^0.5.3",
                 "glob": "^10.3.5",
                 "govuk-frontend": "^4.7.0",
                 "js-yaml": "^4.1.0",
@@ -4075,11 +4074,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
             "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
-        },
-        "node_modules/express-sse": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/express-sse/-/express-sse-0.5.3.tgz",
-            "integrity": "sha512-DJF0nofFGq0IXJLGq95hfrryP3ZprVAVpyZUnmAk6QhHnm7zCzsHBNFP0i4FKFo2XjOf+JiYUKjT7jQhIeljpg=="
         },
         "node_modules/express/node_modules/cookie": {
             "version": "0.5.0",
@@ -11196,11 +11190,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
             "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
-        },
-        "express-sse": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/express-sse/-/express-sse-0.5.3.tgz",
-            "integrity": "sha512-DJF0nofFGq0IXJLGq95hfrryP3ZprVAVpyZUnmAk6QhHnm7zCzsHBNFP0i4FKFo2XjOf+JiYUKjT7jQhIeljpg=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "axios": "^1.5.0",
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
-        "express-sse": "^0.5.3",
         "glob": "^10.3.5",
         "govuk-frontend": "^4.7.0",
         "js-yaml": "^4.1.0",

--- a/src/controllers/health.check.controller.ts
+++ b/src/controllers/health.check.controller.ts
@@ -4,7 +4,7 @@ import { logger } from "../utils/logger";
 export const healthCheckController = Router({ mergeParams: true });
 
 function healthCheck(req: Request, res: Response) {
-    logger.debug(`health check triggered`);
+    logger.traceRequest(req, "Healthcheck triggered.");
     return res.sendStatus(200);
 }
 

--- a/src/utils/sseManager.ts
+++ b/src/utils/sseManager.ts
@@ -1,0 +1,24 @@
+import { Response } from "express";
+
+export class SSEManager {
+    private response: Response;
+
+    constructor(res: Response) {
+        this.response = res;
+        this.init();
+    }
+
+    private init() {
+        this.response.setHeader('Content-Type', 'text/event-stream');
+        this.response.setHeader('Cache-Control', 'no-cache');
+        this.response.setHeader('Connection', 'keep-alive');
+    }
+
+    send(data: any) {
+        this.response.write(`data: ${JSON.stringify(data)}\n\n`);
+    }
+
+    close() {
+        this.response.end();
+    }
+}


### PR DESCRIPTION
The package `express-sse` was incompatible with the version of express used by the service. 
The official fix was to downgrade `express-sse`.
After a small investigation  it was decided the `express-sse` library didn't provide much functionality and so this PR implements that functionality in the service itself based u pon the information from https://stackoverflow.com/questions/34657222/how-to-use-server-sent-events-in-express-js.

Additionally, it changes the log level of the healthcheck endpoint log to `trace` to prevent log pollution.

