### PR TITLE
Removed redundant env vars

### DIFF
--- a/src/controllers/submit.controller.ts
+++ b/src/controllers/submit.controller.ts
@@ -82,7 +82,7 @@ async function submitFileForValidation(
         return;
     }
 
-    logger.debug(`Submitting file to account-validator-api for validation`);
+    logger.debug(`Submitting file to account-validator-api for validation. File name ${req.file?.filename}`);
     // We know the file is not undefined since if the validation did not succeed we wouldn't have made it to this point
     req.accountValidationResult = await accountValidatorService.submit(
         req.file! // eslint-disable-line @typescript-eslint/no-non-null-assertion

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -57,39 +57,33 @@ locals {
   }
 
   task_secrets = [
-    { "name" : "COOKIE_SECRET", "valueFrom" : "${local.secrets_arn_map.web-oauth2-cookie-secret}" },
+    { "name" : "ACCOUNT_TEST_URL", "valueFrom" : "${local.service_secrets_arn_map.account_test_url}" },
+    { "name" : "ACCOUNT_URL", "valueFrom" : "${local.service_secrets_arn_map.account_url}" },
     { "name" : "CHS_API_KEY", "valueFrom" : "${local.service_secrets_arn_map.chs_api_key}" },
     { "name" : "CHS_INTERNAL_API_KEY", "valueFrom" : "${local.service_secrets_arn_map.chs_internal_api_key}" },
-    { "name" : "ACCOUNT_URL", "valueFrom" : "${local.service_secrets_arn_map.account_url}" },
-    { "name" : "ACCOUNT_TEST_URL", "valueFrom" : "${local.service_secrets_arn_map.account_test_url}" },
+    { "name" : "COOKIE_SECRET", "valueFrom" : "${local.secrets_arn_map.web-oauth2-cookie-secret}" },
     { "name" : "INTERNAL_API_URL", "valueFrom" : "${local.service_secrets_arn_map.internal_api_url}" },
     { "name" : "OAUTH2_AUTH_URI", "valueFrom" : "${local.service_secrets_arn_map.oauth2_auth_uri}" },
-    { "name" : "OAUTH2_REDIRECT_URI", "valueFrom" : "${local.service_secrets_arn_map.oauth2_token_uri}" },
-    { "name" : "OAUTH2_TOKEN_URI", "valueFrom" : "${local.service_secrets_arn_map.oauth2_redirect_uri}" },
     { "name" : "OAUTH2_CLIENT_ID", "valueFrom" : "${local.service_secrets_arn_map.oauth2_client_id}" },
     { "name" : "OAUTH2_CLIENT_SECRET", "valueFrom" : "${local.service_secrets_arn_map.oauth2_client_secret}" },
-    { "name" : "OAUTH2_REQUEST_KEY", "valueFrom" : "${local.service_secrets_arn_map.oauth2_request_key}" }
+    { "name" : "OAUTH2_REDIRECT_URI", "valueFrom" : "${local.service_secrets_arn_map.oauth2_token_uri}" },
+    { "name" : "OAUTH2_REQUEST_KEY", "valueFrom" : "${local.service_secrets_arn_map.oauth2_request_key}" },
+    { "name" : "OAUTH2_TOKEN_URI", "valueFrom" : "${local.service_secrets_arn_map.oauth2_redirect_uri}" },
   ]
 
   task_environment = [
-    { "name" : "ACCOUNT_WEB_URL", "value" : "${var.account_web_url}" },
-    { "name" : "ALLOWED_COMPANY_PREFIXES", "value" : "${var.allowed_company_prefixes}" },
-    { "name" : "API_URL", "value" : "${var.api_url}" },
     { "name" : "ACCOUNT_VALIDATOR_MAX_FILE_SIZE", "value" : "${var.account_validator_max_file_size}" },
+    { "name" : "ACCOUNT_VALIDATOR_UI_UPDATE_INTERVAL", "value" : "${var.account_validator_ui_update_interval}" },
+    { "name" : "ACCOUNT_VALIDATOR_UI_UPDATE_TIMEOUT", "value" : "${var.account_validator_ui_update_timeout}" },
     { "name" : "ACCOUNT_VALIDATOR_WEB_VERSION", "value" : "${var.account_validator_web_version}" },
+    { "name" : "API_URL", "value" : "${var.api_url}" },
     { "name" : "CACHE_SERVER", "value" : "${var.cache_server}" },
     { "name" : "CDN_HOST", "value" : "${var.cdn_host}" },
     { "name" : "CHS_URL", "value" : "${var.chs_url}" },
     { "name" : "COOKIE_DOMAIN", "value" : "${var.cookie_domain}" },
     { "name" : "COOKIE_NAME", "value" : "${var.cookie_name}" },
-    { "name" : "EWF_URL", "value" : "${var.ewf_url}" },
     { "name" : "LOG_LEVEL", "value" : "${var.log_level}" },
-    { "name" : "PIWIK_SITE_ID", "value" : "${var.piwik_site_id}" },
-    { "name" : "PIWIK_URL", "value" : "${var.piwik_url}" },
-    { "name" : "SUPPORTED_MIME_TYPES", "value" : "${var.supported_mime_types}" },
     { "name" : "NODE_ENV", "value" : "${var.node_env}" },
-    { "name" : "TZ", "value" : "${var.tz}" },
-    { "name" : "UI_UPDATE_INTERVAL_SECONDS", "value" : "${var.ui_update_interval_seconds}" }
+    { "name" : "TZ", "value" : "${var.tz}" }
   ]
-
 }

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -1,27 +1,20 @@
 environment = "cidev"
 aws_profile = "development-eu-west-2"
 
-account_web_url = "https://account.cidev.aws.chdev.org"
 api_url = "https://api.cidev.aws.chdev.org"
 account_validator_max_file_size = "300MB"
-allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
+
 required_memory = "2048"
+
 cache_server = "redis"
 cdn_host = "https://d3uvya5a8a1ncx.cloudfront.net"
-
 chs_url = "https://cidev.aws.chdev.org"
-
 cookie_domain = "cidev.aws.chdev.org"
 cookie_name = "__SID"
 
-ewf_url = "https://ewf.companieshouse.gov.uk/"
-
-piwik_site_id = "7"
-piwik_url = "https://matomo.platform.aws.chdev.org"
-log_level = "trace"
-node_env = "docker"
+log_level = "debug"
+node_env = "production"
 tz = "Europe/London"
-supported_mime_types = "application/pdf,image/jpeg,image/png,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/zip,application/octet-stream,application/x-zip-compressed,application/x-zip,multipart/x-zip,image/gif,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
-ui_update_interval_seconds = "1"
-
+account_validator_ui_update_interval = "1s"
+account_validator_ui_update_timeout = "15m"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -1,10 +1,8 @@
 environment = "live"
 aws_profile = "live-eu-west-2"
 
-account_web_url =  "https://identity.company-information.service.gov.uk"
 api_url = "https://private-api.companieshouse.gov.uk"
 account_validator_max_file_size = "300MB"
-allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
 cache_server = "redis"
 cdn_host = "https://db2062spq951s.cloudfront.net"
 
@@ -13,14 +11,10 @@ chs_url = "https://staging.company-information.service.gov.uk"
 cookie_domain = "company-information.service.gov.uk"
 cookie_name = "__SID"
 
-ewf_url = "https://ewf.companieshouse.gov.uk/"
-
 file_transfer_api_url = "https://9rwq9ydff0-vpce-0ffeb1a278a21fc36.execute-api.eu-west-2.amazonaws.com/staging/files"
-piwik_site_id = "15"
-piwik_url = "https://matomo.platform.aws.chdev.org"
-log_level = "debug"
-node_env = "docker"
+log_level = "info"
+node_env = "production"
 tz = "Europe/London"
-supported_mime_types = "application/pdf,image/jpeg,image/png,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/zip,application/octet-stream,application/x-zip-compressed,application/x-zip,multipart/x-zip,image/gif,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
-ui_update_interval_seconds = "1"
+account_validator_ui_update_interval="10s"
+account_validator_ui_update_timeout = "15m"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -1,10 +1,8 @@
 environment = "staging"
 aws_profile = "staging-eu-west-2"
 
-account_web_url =  "https://identity-staging.company-information.service.gov.uk"
 api_url = "https://private-api-staging.company-information.service.gov.uk"
 account_validator_max_file_size = "300MB"
-allowed_company_prefixes = "SC,NI,OC,SO,R,AP"
 cache_server = "redis"
 cdn_host = "https://d6nh3dxv55e16.cloudfront.net"
 
@@ -13,16 +11,9 @@ chs_url = "https://staging.company-information.service.gov.uk"
 cookie_domain = "company-information.service.gov.uk"
 cookie_name = "__SID"
 
-ewf_url = "https://ewf.companieshouse.gov.uk/"
-
-piwik_site_id = "15"
-piwik_url = "https://matomo.platform.aws.chdev.org"
-log_level = "debug"
-node_env = "docker"
+log_level = "info"
+node_env = "production"
 tz = "Europe/London"
-supported_mime_types = "application/pdf,image/jpeg,image/png,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/zip,application/octet-stream,application/x-zip-compressed,application/x-zip,multipart/x-zip,image/gif,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
-ui_update_interval_seconds = "1"
-
-
-
+account_validator_ui_update_interval = "10s"
+account_validator_ui_update_timeout = "15m"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -61,14 +61,6 @@ variable "api_url" {
   type = string
 }
 
-variable "account_web_url" {
-  type = string
-}
-
-variable "allowed_company_prefixes" {
-  type = string
-}
-
 variable "account_validator_max_file_size" {
   type = string
 }
@@ -93,22 +85,6 @@ variable "cookie_name" {
   default = "__SID"
 }
 
-variable "ewf_url" {
-  type = string
-}
-
-variable "piwik_site_id" {
-  type = string
-}
-
-variable "piwik_url" {
-  type = string
-}
-
-variable "supported_mime_types" {
-  type = string
-}
-
 variable "node_env" {
   type = string
 }
@@ -117,6 +93,10 @@ variable "tz" {
   type = string
 }
 
-variable "ui_update_interval_seconds" {
+variable "account_validator_ui_update_interval" {
+  type = string
+}
+
+variable "account_validator_ui_update_timeout" {
   type = string
 }


### PR DESCRIPTION
1. **Enhanced Debugging**: Improved the debug logging in `submit.controller.ts` by including the file name during the submission to the `account-validator-api`.
  
2. **Optimized Environment Variables**:
    - Removed redundant environment variables such as `account_web_url`, `allowed_company_prefixes`, `ewf_url`, `piwik_site_id`, `piwik_url`, and `supported_mime_types`.
    - Added variables `account_validator_ui_update_interval` and `account_validator_ui_update_timeout`.
    - Sorted the order of the environment variables alphabetically for consistency across the codebase.

3. **Configuration Profile Updates**:
    - Updated the `development-eu-west-2/cidev/vars`, `live-eu-west-2/live/vars`, and `staging-eu-west-2/staging/vars` profiles reflecting the changes in environment variables.
    - Changed the `log_level` in certain profiles fto prevent log pollution from trace events.
    - Switched `node_env` from `docker` to `production` to conform to convention.


Please review the changes, and let me know if any adjustments are needed.