### PR TITLE
Remove import to old dependency

### DIFF
--- a/build-static-assets.ts
+++ b/build-static-assets.ts
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import path from "path";
-import { globPlugin } from "esbuild-plugin-glob";
 
 async function buildAssets() {
     const srcDir = path.join(__dirname, "assets/src");
@@ -16,7 +15,6 @@ async function buildAssets() {
             // sourcemap: true, // Uncomment this to emit a source map to view the typescript code in the browser
             minify: true,
             format: "iife",
-            plugins: [globPlugin()],
         });
     } catch (error) {
         console.error(`Error building static assets: ${error.message}`);


### PR DESCRIPTION
A depreciated dependency was removed in https://github.com/companieshouse/account-validator-web/pull/87/files but the import in `build-static-assets.ts` was not causing the build to fail.
This PR remove the import and fixes the build.