### PR TITLE
Add back button url query parameter

### DIFF
--- a/src/controllers/submit.controller.ts
+++ b/src/controllers/submit.controller.ts
@@ -1,6 +1,6 @@
 import { Response, Request, Router, NextFunction } from "express";
 import { MAX_FILE_SIZE, MAX_FILE_SIZE_MB, UI_UPDATE_TIMEOUT_MS } from "../config";
-import { ErrorMessages, FILE_UPLOAD_FIELD_NAME, Templates, errorMessage } from "../constants";
+import { ErrorMessages, FILE_UPLOAD_FIELD_NAME, Templates, errorMessage, Urls } from "../constants";
 import multer from "multer";
 import { ValidationResult } from "../validation/validation.result";
 import {
@@ -69,7 +69,8 @@ function renderSubmitPage(req: SubmitPageRequest, res: Response) {
         fileName: req.file?.originalname,
         FILE_UPLOAD_FIELD_NAME: FILE_UPLOAD_FIELD_NAME,
         errorMessage: errorMessage,
-        callback: req.query.callback
+        callback: req.query.callback,
+        backUrl: req.query.backUrl ?? Urls.BASE
     });
 }
 

--- a/views/submit/submit.html
+++ b/views/submit/submit.html
@@ -19,7 +19,7 @@
     {# Go back to the start page #}
     {{ govukBackLink({
     text: "Back",
-    href: Urls.BASE
+    href: backUrl
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
When redirecting to this service from an external service the back button on the `submit` page went back to the validator home page, instead of the other services previous page.

To fix this I have added functionality to configure the back button url on the submit page via a query parameter `backUrl`.
This is then passed through to the template and attched to the back button. If no `backUrl` is passed then it will return to the previous page. 

Here is a related PR to use this functionality in the `accounts-filing-web` service https://github.com/companieshouse/accounts-filing-web/pull/46