### PR TITLE
Use regular node images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/local/configure-local-ssh
-FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-20
-
-RUN dnf install -y tar
+FROM node:18-bookworm
 
 COPY --from=0 ./ ./
 
 WORKDIR /opt
-
-COPY node_modules ./node_modules
 
 COPY . .
 

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 # Start script for account-validator-web
-# Install specific version only for local docker
-npm i @swc/core-linux-arm64-gnu
-PORT=3000
-export NODE_PORT=${PORT}
-exec npm run dev -- ${PORT}
+
+if [ ! -d "node_modules" ]; then
+    echo "node_modules directory does not exist. Attempting to install dependencies..."
+    if ! npm install; then
+        echo "npm install failed or timed out. Please run 'npm install' in the account-validator-web directory manually before starting the service."
+        exit 1
+    fi
+fi
+
+echo "Starting the account-validator-web service..."
+npm run dev

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,5 @@
     ],
     "exclude": [
         "node_modules"
-    ],
-    "ts-node": {
-        "swc": true
-    }
+    ]
 }


### PR DESCRIPTION
Updates to docker dev local dev env. 
- Remove SWC compiler 
- Change base image to regular node image instead of ci-node-runtime so that it works better on arm based computers
- Pass through node_modules folder from the build context to prevent timeouts when installing dependencies at runtime