### PR TITLE
Increase task memory to 4GB

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -9,3 +9,7 @@ log_level = "debug"
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+# Resource limits
+required_cpus = 512
+required_memory = 4096


### PR DESCRIPTION
Increase memory to 4GB to allow for ZIP bomb testing