### PR TITLE
Use chgovuk loadbalancer zip portal

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,8 +13,10 @@ export enum Templates {
 export enum Urls {
     BASE = "/xbrl_validate",
     RENDER = `/xbrl_validate/render`,
-    SUBMIT_SUFFIX = "/submit",
-    SUBMIT = "/xbrl_validate/submit",
+    SUBMIT_SUFFIX = "/submit-accounts",
+    SUBMIT = "/xbrl_validate/submit-accounts",
+    SUBMIT_PACKAGE_SUFFIX = "/submit",
+    SUBMIT_PACKAGE = "/xbrl_validate/submit",
     SUBMIT_VALIDATE_SUFFIX = "/submit/validate",
     SUBMIT_VALIDATE = "/xbrl_validate/submit/validate",
     RESULT_SUFFIX = "/result",

--- a/src/controllers/submit.controller.ts
+++ b/src/controllers/submit.controller.ts
@@ -75,11 +75,13 @@ function renderSubmitPage(req: SubmitPageRequest, res: Response) {
         userEmail = req.session?.data.signin_info?.user_profile?.email;
     }
 
-    const submitUrl = Urls.SUBMIT + getSubmitQueryParams(req);
+    let submitUrl;
     let submitPage;
     if (packageType !== undefined) {
+        submitUrl = Urls.SUBMIT_PACKAGE + getSubmitQueryParams(req);
         submitPage = Templates.SUBMIT_PACKAGE_ACCOUNT;
     } else {
+        submitUrl = Urls.SUBMIT + getSubmitQueryParams(req);
         submitPage = Templates.SUBMIT;
     }
     return res.render(submitPage, {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -26,7 +26,8 @@ router.use(Urls.HEALTH_CHECK_SUFFIX, healthCheckController);
 
 router.use('/', startController);
 router.use('/render/:id', renderController);
-router.use(Urls.SUBMIT_SUFFIX, sessionMiddleware(sessionStore), EnsureSessionCookiePresentMiddleware(COOKIE_CONFIG), authenticationMiddleware, submitController);
+router.use(Urls.SUBMIT_SUFFIX, submitController);
+router.use(Urls.SUBMIT_PACKAGE_SUFFIX, sessionMiddleware(sessionStore), EnsureSessionCookiePresentMiddleware(COOKIE_CONFIG), authenticationMiddleware, submitController);
 router.use(`${Urls.RESULT_SUFFIX}/:id`, resultController);
 router.use(Urls.PROGRESS_SUFFIX, progressController);
 router.use(Urls.ERROR_SUFFIX, errorController);

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -42,6 +42,15 @@ data "aws_lb_listener" "filing_maintain_lb_listener" {
   port              = 443
 }
 
+data "aws_lb" "secondary_lb" {
+  name = "${var.environment}-chs-chgovuk"
+}
+
+data "aws_lb_listener" "secondary_lb_listener" {
+  load_balancer_arn = data.aws_lb.secondary_lb.arn
+  port = 443
+}
+
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {
   path = "/${local.name_prefix}"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -43,6 +43,17 @@ module "ecs-service" {
   lb_listener_arn           = data.aws_lb_listener.filing_maintain_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority
   lb_listener_paths         = local.lb_listener_paths
+  multilb_setup             = true
+  multilb_listeners         = {
+    "chgovuk-lb": {
+      listener_arn            = data.aws_lb_listener.secondary_lb_listener.arn
+      load_balancer_arn       = data.aws_lb.secondary_lb.arn
+    }
+    "account-validator-lb": {
+      listener_arn           = data.aws_lb_listener.filing_maintain_lb_listener.arn
+      load_balancer_arn      = data.aws_lb.filing_maintain_lb.arn
+    }
+  }
 
   # Docker container details
   docker_registry           = var.docker_registry

--- a/test/controller/submit.controller.unit.ts
+++ b/test/controller/submit.controller.unit.ts
@@ -27,7 +27,7 @@ describe("Submit controller tests", () => {
         expect(response.text).toContain(fileUploadHtml);
         const hiddenPendingPage = `id="pending" class="govuk-grid-row govuk-!-display-none"`;
         expect(response.text).toContain(hiddenPendingPage);
-        const submitUrl = `action="/xbrl_validate/submit"`;
+        const submitUrl = `action="/xbrl_validate/submit-accounts"`;
         expect(response.text).toContain(submitUrl);
     });
 
@@ -42,7 +42,7 @@ describe("Submit controller tests", () => {
 
     it("Should render the submit page with package type uksef", async () => {
         Object.assign(mockSession, getSessionRequest());
-        const response = await getRequestWithCookie(Urls.SUBMIT + "/?packageType=uksef");
+        const response = await getRequestWithCookie(Urls.SUBMIT_PACKAGE + "/?packageType=uksef");
 
         expect(response.status).toBe(200);
         expect(response.text).toContain("Upload your package accounts zip file then select validate");
@@ -56,7 +56,7 @@ describe("Submit controller tests", () => {
 
     it("Should render the submit page with package type group-package-401", async () => {
         Object.assign(mockSession, getSessionRequest());
-        const response = await getRequestWithCookie(Urls.SUBMIT + "/?packageType=group-package-401");
+        const response = await getRequestWithCookie(Urls.SUBMIT_PACKAGE + "/?packageType=group-package-401");
 
         expect(response.status).toBe(200);
         expect(response.text).toContain("Upload your package accounts zip file then select validate");
@@ -70,14 +70,14 @@ describe("Submit controller tests", () => {
 
     it("Should render the submit page with package type group-package-5 not signed in", async () => {
 
-        const response = await getRequestWithCookie(Urls.SUBMIT + "/?packageType=group-package-5");
+        const response = await getRequestWithCookie(Urls.SUBMIT_PACKAGE + "/?packageType=group-package-5");
 
         expect(response.status).toBe(302);
     });
 
     it("Should render the submit page with package type group-package-5", async () => {
         Object.assign(mockSession, getSessionRequest());
-        const response = await getRequestWithCookie(Urls.SUBMIT + "/?packageType=group-package-5");
+        const response = await getRequestWithCookie(Urls.SUBMIT_PACKAGE + "/?packageType=group-package-5");
 
         expect(response.status).toBe(500);
     });
@@ -176,7 +176,7 @@ describe("Submit controller tests", () => {
     it('Should error when package type is not valid', async () => {
         Object.assign(mockSession, getSessionRequest());
         mockSession.setExtraData(PACKAGE_TYPE_KEY, "uksef");
-        const response = await getRequestWithCookie(Urls.SUBMIT + "/?packageType=not_valid");
+        const response = await getRequestWithCookie(Urls.SUBMIT_PACKAGE + "/?packageType=not_valid");
         expect(response.status).toBe(500);
     });
 
@@ -185,7 +185,7 @@ describe("Submit controller tests", () => {
         Object.assign(mockSession, getSessionRequest());
         mockSession.setExtraData(PACKAGE_TYPE_KEY, "welsh");
         const response = await request(app)
-            .post(Urls.SUBMIT + "/?packageType=uksef").set("Cookie", setCookie())
+            .post(Urls.SUBMIT_PACKAGE + "/?packageType=uksef").set("Cookie", setCookie())
             .attach(FILE_UPLOAD_FIELD_NAME, Buffer.from(`PK\u0003\u0004`), { filename: 'test_file.zip' });
         expect(response.status).toBe(500);
     });
@@ -199,7 +199,7 @@ describe("Submit controller tests", () => {
         Object.assign(mockSession, getSessionRequest());
         mockSession.setExtraData(PACKAGE_TYPE_KEY, "uksef");
         const response = await request(app)
-            .post(Urls.SUBMIT + "/?packageType=uksef").set("Cookie", setCookie())
+            .post(Urls.SUBMIT_PACKAGE + "/?packageType=uksef").set("Cookie", setCookie())
             .attach(FILE_UPLOAD_FIELD_NAME, Buffer.from(`PK\u0003\u0004`), { filename: 'test_file.zip' });
         expect(response.status).toBe(200);
     });


### PR DESCRIPTION
This pr does two things:
1. Add the chgovuk load balancer to the test validator, this way the zip portal can use the standard domain throughout the journey and the cookie can stay consistent
2. Change the submit url to be unique to the zip portal journey, this way the session and auth middleware are only called on that journey and not on the validator one.