### PR TITLE
JU-1231 - Update AccountValidator to use new File Transfer Service

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,6 +36,7 @@ export const NUNJUCKS_RELOAD = getEnvironmentVariable("NUNJUCKS_RELOAD", "0") ==
 export const SIGN_OUT = getEnvironmentVariable("SIGN_OUT_URL", "/signout");
 export const PIWIK_URL = getEnvironmentVariable("PIWIK_URL");
 export const PIWIK_SITE_ID = getEnvironmentVariable("PIWIK_SITE_ID");
+export const FILE_TRANSFER_API_URL = getEnvironmentVariable("FILE_TRANSFER_API_URL");
 
 /**
  * Parses a file size string and returns the equivalent number of bytes.

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -26,7 +26,7 @@ export const createPublicApiKeyClient = (): ApiClient => {
     return createApiClient(CHS_API_KEY, undefined, API_URL);
 };
 
-export const createPrivateApiKeyClient = (): PrivateApiClient => {
+export const createPrivateApiKeyClient = (basePath: string = INTERNAL_API_URL): PrivateApiClient => {
     logger.info(
         `Creating private API client with key ${maskString(
             CHS_INTERNAL_API_KEY
@@ -36,7 +36,7 @@ export const createPrivateApiKeyClient = (): PrivateApiClient => {
     const sdkClient =  createPrivateApiClient(
         CHS_INTERNAL_API_KEY,
         undefined,
-        INTERNAL_API_URL
+        basePath
     );
 
     const apiClient = new LargeBodyRequestClient(sdkClient.apiClient as RequestClient, base64Size(MAX_FILE_SIZE));

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -15,4 +15,5 @@ export default () => {
     process.env.API_CALL_RETRY_DELAY_MS = "0";
     process.env.PIWIK_URL = "https://www.matomo.com";
     process.env.PIWIK_SITE_ID = "99";
+    process.env.FILE_TRANSFER_API_URL = "http://localhost:1234";
 };

--- a/test/service/account.validator.service.unit.ts
+++ b/test/service/account.validator.service.unit.ts
@@ -1,4 +1,3 @@
-import PrivateApiClient from "private-api-sdk-node/dist/client";
 import {
     AccountValidationService,
     AccountValidator,
@@ -6,23 +5,22 @@ import {
 } from "../../src/services/account.validation.service";
 import { Resource } from "@companieshouse/api-sdk-node";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
-import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
 import { Id } from "private-api-sdk-node/dist/services/file-transfer/types";
+import { AccountValidatorService as PrivateApiAccountValidatorService } from "private-api-sdk-node/dist/services/account-validator";
+import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
+import FileTransferService from "private-api-sdk-node/dist/services/file-transfer/services";
 
-const mockPrivateApiClient = {
-    accountValidatorService: {
-        postFileForValidation: jest.fn(),
-        getFileValidationStatus: jest.fn(),
-
-    },
-    fileTransferService: {
-        upload: () => {
-            return Promise.resolve(
-                    { resource: { id: "123" } } as unknown as Resource<Id>
-            );
-        }
+const mockAccountValidatorService = {
+    postFileForValidation: jest.fn(),
+    getFileValidationStatus: jest.fn(),
+} as unknown as PrivateApiAccountValidatorService;
+const mockFileTransferService = {
+    upload: () => {
+        return Promise.resolve(
+                { resource: { id: "123" } } as unknown as Resource<Id>
+        );
     }
-} as unknown as PrivateApiClient;
+} as unknown as FileTransferService;
 
 function createAccountValidatorResponse(
     httpStatusCode: number,
@@ -89,13 +87,11 @@ describe("validFileForRendering", () => {
 });
 
 let accountValidator: AccountValidationService;
-const mockPostForValidation = mockPrivateApiClient.accountValidatorService
-    .postFileForValidation as jest.Mock;
-const mockGetFileValidationStatus = mockPrivateApiClient.accountValidatorService
-    .getFileValidationStatus as jest.Mock;
+const mockPostForValidation = mockAccountValidatorService.postFileForValidation as jest.Mock;
+const mockGetFileValidationStatus = mockAccountValidatorService.getFileValidationStatus as jest.Mock;
 describe("AccountValidator", () => {
     beforeEach(() => {
-        accountValidator = new AccountValidator(mockPrivateApiClient);
+        accountValidator = new AccountValidator(mockAccountValidatorService, mockFileTransferService);
     });
 
     it("should submit a file to the api for validation", async () => {


### PR DESCRIPTION
Update the file transfer service upload functionality to point at the new ECS file transfer service endpoint.

As part of [JU-1231 - Update account-validator-web to use file-transfer-service on ECS](https://companieshouse.atlassian.net/browse/JU-1231)