### PR TITLE
Encode file name to prevent s3 error

### DIFF
--- a/src/services/account.validation.service.ts
+++ b/src/services/account.validation.service.ts
@@ -294,8 +294,14 @@ export class AccountValidator implements AccountValidationService {
         // TODO: Change body type to string
         const body = file.buffer.toString("base64");
         logger.debug(`Body size: ${body.length} Sample ${body.slice(0, 10)}`);
+
+        // TEMPORARY: URL-encode the filename to handle non-ASCII characters
+        // This is a workaround for S3 metadata limitations (which only supports ASCII)
+        // TODO: Remove once file-transfer-service handles encoding on its end
+        const encodedFileName = encodeURIComponent(file.originalname);
+
         const fileDetails: File = {
-            fileName: file.originalname,
+            fileName: encodedFileName,
             body: body,
             mimeType: file.mimetype,
             size: file.size,


### PR DESCRIPTION
A bug in the file-transfer-service prevents file names with non-ascii charcters.
This work around fixes that until the file-transfer-service can be fixed.


Resolves: [AS-41](https://companieshouse.atlassian.net/browse/AS-41)

[AS-41]: https://companieshouse.atlassian.net/browse/AS-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ