### PR TITLE
Add dependency-check target to Makefile for npm audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,7 @@ dist: lint test clean package
 .PHONY: security-check
 security-check:
 	npm audit
+
+.PHONY: dependency-check
+dependency-check:
+	npm audit


### PR DESCRIPTION
- Introduced a new .PHONY target 'dependency-check' in the Makefile.
- This target runs 'npm audit' to check for vulnerabilities in dependencies.